### PR TITLE
A reference guide to JavaScript promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ## Promises (JavaScript exceptions and promises)
 * https://web.dev/promises
+* https://dev.to/saroj990/mastering-javascript-promises-4kfh
 
 ## Service Workers
 A service worker is a script that your browser runs in the background, separate from a web page, opening the door to features that don't need a web page or user interaction.


### PR DESCRIPTION
The current reference guide to javascript promises is good enough [https://web.dev/promises] but since this repo is designed for beginners, it is our sole purpose to make the reference articles/post as engaging as possible.

In this post [https://web.dev/promises] when viewed on mobile the paragraphs are stretched to a big wall of text, and it decreases the reader's interaction or interest. That's why I proposed "https://dev.to/saroj990/mastering-javascript-promises-4kfh" which is engaging, beginner friendly, and the paragraphs are already broken down for larger screen sizes(desktops). So when it is viewed on smaller screen sizes it's not been transformed into a huge wall of text content plus a consistent number of, to-the-point examples makes it more appealing to the reader.